### PR TITLE
Fixes warning by removing props from SVG

### DIFF
--- a/src/FitterHappierText.jsx
+++ b/src/FitterHappierText.jsx
@@ -56,7 +56,7 @@ class FitterHappierText extends React.Component {
     ].join(' ')
 
     return (
-      <svg {...this.props}
+      <svg
         viewBox={viewBox}
         style={styles.svg}>
         <text


### PR DESCRIPTION
I’m not totally sure if this is the right way to fix this, but these prop names are creating warnings in React.
