### PR TITLE
Uses source file as main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-fitter-happier-text",
   "version": "1.0.2",
   "description": "React component for fully fluid headings",
-  "main": "FitterHappierText.js",
+  "main": "./src/FitterHappierText.jsx",
   "scripts": {
     "babel": "babel src --out-dir .",
     "babel:watch": "babel -w src --out-dir .",


### PR DESCRIPTION
There might be a better way to do this to maintain compatibility with other build systems, but right now it was necessary for me to path to the source file to use the module with Babel and Webpack. 

The compiled file was causing this error:

```
Uncaught TypeError: _react2.default.findDOMNode is not a function
```
